### PR TITLE
fix skip net/http.Request method call condition

### DIFF
--- a/reqwithoutctx/ssa.go
+++ b/reqwithoutctx/ssa.go
@@ -97,7 +97,7 @@ func (a *Analyzer) usedReqByCall(call *ssa.Call) []*ssa.Extract {
 	exts := make([]*ssa.Extract, 0, len(args))
 
 	// skip net/http.Request method call
-	if call.Common().Signature().Recv() != nil && types.Identical(call.Value().Type(), a.requestType) {
+	if recv := call.Common().Signature().Recv(); recv != nil && types.Identical(recv.Type(), a.requestType) {
 		return exts
 	}
 

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -132,6 +132,6 @@ func main() {
 
 	req121, _ := http.NewRequest(http.MethodPost, url, nil) // OK
 	req121.AddCookie(&http.Cookie{Name: "k", Value: "v"})
-	req121 = req121.WithContext(context.WithValue(req.Context(), struct{}{}, 0))
+	req121 = req121.WithContext(context.WithValue(req121.Context(), struct{}{}, 0))
 	cli.Do(req121)
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -129,4 +129,9 @@ func main() {
 
 		return req14, req15
 	}()
+
+	req121, _ := http.NewRequest(http.MethodPost, url, nil) // OK
+	req121.AddCookie(&http.Cookie{Name: "k", Value: "v"})
+	req121 = req121.WithContext(context.WithValue(req.Context(), struct{}{}, 0))
+	cli.Do(req121)
 }


### PR DESCRIPTION
It seems that the `// skip net/http.Request method call` process is not working properly.
For example, calling `req.AddCookie()` or `req.Context()` causes a false positive.

Related https://github.com/sonatard/noctx/issues/10.