### PR TITLE
fix: Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,17 @@
 name: CI
+
 on:
   push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23', '1.22' ]
+        go: [ stable, oldstable ]
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +23,7 @@ jobs:
       - run: make lint
       - run: make test_coverage
       - name: Upload code coverage to codecov
-        if: matrix.go == '1.23'
+        if: matrix.go == 'stable'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.x
+          go-version: stable
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.out
+/noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,38 @@
-run:
-  linters-settings:
-    govet:
-       enable-all: true
-  linters:
-    enable-all: true
-    disable:
-      - gochecknoglobals
-      - gomnd
-      - gocognit
-      - nestif
-      - nilnil
-      - paralleltest
-      - varnamelen
+linters:
+  enable-all: true
+  disable:
+    - execinquery # deprecated
+    - exportloopref # deprecated
+    - gomnd # deprecated
+    - gochecknoglobals
+    - exhaustruct
+    - mnd
+    - gocognit
+    - nestif
+    - nilnil
+    - paralleltest
+    - varnamelen
+
+linters-settings:
+  govet:
+     enable-all: true
+  perfsprint:
+    err-error: true
+    errorf: true
+    sprintf1: true
+    strconcat: false
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/instana/testify"
+            desc: not allowed
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
+
+output:
+  show-stats: true
+  sort-results: true
+  sort-order:
+    - linter
+    - file

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,37 @@
+version: 2
+project_name: noctx
+
+builds:
+  - binary: noctx
+
+    main: ./cmd/noctx/main.go
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 7
+      - 6
+      - 5
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+archives:
+  - id: noctx
+    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all imports test lint
+.PHONY: all imports test lint build
 
-all: imports test lint
+all: imports test lint build
 
 imports:
 	goimports -w ./
@@ -14,3 +14,5 @@ test_coverage:
 lint:
 	golangci-lint run ./...
 
+build:
+	go build -ldflags "-s -w" -trimpath ./cmd/noctx/

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ linters:
 $ golangci-lint run
 
 # Only noctx execute
-golangci-lint run --disable-all -E noctx
+golangci-lint run --enable-only noctx
 ```
 
 ## Detection rules
+
 - Executing following functions
   - `net/http.Get`
   - `net/http.Head`
@@ -68,6 +69,7 @@ golangci-lint run --disable-all -E noctx
 - `http.Request` returned by `http.NewRequest` function and passes it to other function.
 
 ## How to fix
+
 - Send http request using `(*http.Client).Do(*http.Request)` method.
 - In Go 1.13 and later, use `http.NewRequestWithContext` function instead of using `http.NewRequest` function.
 - In Go 1.12 and earlier, call `(http.Request).WithContext(ctx)` after `http.NewRequest`.
@@ -168,6 +170,7 @@ func main() {
 ```
 
 ## Reference
+
 - [net/http - NewRequest](https://golang.org/pkg/net/http/#NewRequest)
 - [net/http - NewRequestWithContext](https://golang.org/pkg/net/http/#NewRequestWithContext)
 - [net/http - Request.WithContext](https://golang.org/pkg/net/http/#Request.WithContext)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sonatard/noctx
 
-go 1.22.5
+go 1.22.0
 
 require (
 	github.com/gostaticanalysis/analysisutil v0.7.1

--- a/ngfunc/main.go
+++ b/ngfunc/main.go
@@ -39,6 +39,7 @@ func ngCalledFuncs(pass *analysis.Pass, ngFuncs []*types.Func) []*Report {
 	if !ok {
 		panic(fmt.Sprintf("%T is not *buildssa.SSA", pass.ResultOf[buildssa.Analyzer]))
 	}
+
 	for _, sf := range ssa.SrcFuncs {
 		for _, b := range sf.Blocks {
 			for _, instr := range b.Instrs {

--- a/ngfunc/types.go
+++ b/ngfunc/types.go
@@ -1,7 +1,7 @@
 package ngfunc
 
 import (
-	"fmt"
+	"errors"
 	"go/types"
 	"strings"
 
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-var errNotFound = fmt.Errorf("function not found")
+var errNotFound = errors.New("function not found")
 
 func typeFuncs(pass *analysis.Pass, funcs []string) []*types.Func {
 	fs := make([]*types.Func, 0, len(funcs))

--- a/noctx.go
+++ b/noctx.go
@@ -2,6 +2,7 @@ package noctx
 
 import (
 	"fmt"
+
 	"github.com/sonatard/noctx/ngfunc"
 	"github.com/sonatard/noctx/reqwithoutctx"
 	"golang.org/x/tools/go/analysis"

--- a/reqwithoutctx/ssa.go
+++ b/reqwithoutctx/ssa.go
@@ -5,7 +5,6 @@ import (
 	"go/types"
 
 	"github.com/gostaticanalysis/analysisutil"
-
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"


### PR DESCRIPTION
Downgrade the min Go version to the first patch.

extra:
- fix release workflow
- fix golangci-lint configuration

---

v0.0.x are not semver compliant because a bug fix cannot happen before a minor release or an impossible initial version v0.0.0.

The first tag should always be at least v0.1.0.

> PATCH version when you make backward compatible bug fixes

https://semver.org/

> How should I deal with revisions in the 0.y.z initial development phase?
>
> The simplest thing to do is start your initial development release at 0.1.0 and then increment the minor version for each subsequent release.

https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase

