### PR TITLE
replace old golang.org links with new pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ func main() {
 
 ## Reference
 
-- [net/http - NewRequest](https://golang.org/pkg/net/http/#NewRequest)
-- [net/http - NewRequestWithContext](https://golang.org/pkg/net/http/#NewRequestWithContext)
-- [net/http - Request.WithContext](https://golang.org/pkg/net/http/#Request.WithContext)
-
+- [net/http - NewRequest](https://pkg.go.dev/net/http#NewRequest)
+- [net/http - NewRequestWithContext](https://pkg.go.dev/net/http#NewRequestWithContext)
+- [net/http - Request.WithContext](https://pkg.go.dev/net/http#Request.WithContext)


### PR DESCRIPTION
This PR replaces the `golang.org/pkg` links with new ones `pkg.go.dev` in README.md.
