### PR TITLE
chore: fix golangci-lint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ linters:
 
 # Or enable-all is true.
 linters:
-  enable-all: true
+  default: all
   disable:
    - xxx # Add unused linter to disable linters.
 ```


### PR DESCRIPTION
enable-all was for golangci-lint v1
