### PR TITLE
Support exec package

### DIFF
--- a/noctx.go
+++ b/noctx.go
@@ -65,6 +65,9 @@ var ngFuncMessages = map[string]string{
 	"(*database/sql.Stmt).Query":    "must not be called. use (*database/sql.Conn).QueryContext",
 	"(*database/sql.Stmt).QueryRow": "must not be called. use (*database/sql.Conn).QueryRowContext",
 
+	// exec
+	"os/exec.Command": "must not be called. use os/exec.CommandContext",
+
 	// crypto/tls dialer
 	"crypto/tls.Dial":              "must not be called. use (*crypto/tls.Dialer).DialContext",
 	"crypto/tls.DialWithDialer":    "must not be called. use (*crypto/tls.Dialer).DialContext with NetDialer",

--- a/noctx_test.go
+++ b/noctx_test.go
@@ -12,6 +12,7 @@ func TestAnalyzer(t *testing.T) {
 		desc string
 	}{
 		{desc: "crypto_tls"},
+		{desc: "exec_cmd"},
 		{desc: "http_client"},
 		{desc: "http_request"},
 		{desc: "network"},

--- a/testdata/src/exec_cmd/exec.go
+++ b/testdata/src/exec_cmd/exec.go
@@ -1,0 +1,14 @@
+package exec
+
+import (
+	"context"
+	"os/exec"
+)
+
+func _() {
+	ctx := context.Background()
+
+	exec.Command("ls", "-l") // want `os/exec.Command must not be called. use os/exec.CommandContext`
+
+	exec.CommandContext(ctx, "ls", "-l")
+}


### PR DESCRIPTION
exec.CommandContext can be used to run commands with a context.
