### PR TITLE
Exclude functions based on patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,42 @@ $ golangci-lint run
 golangci-lint run --enable-only noctx
 ```
 
+## Configuration
+
+### Excluding Functions
+
+You can exclude specific functions from noctx checks using the `exclude` flag. This is useful when you want to allow certain functions without context, such as when using the `log/slog` package where context variants are optional.
+
+#### With go vet
+
+```sh
+$ go vet -vettool=`which noctx` -noctx.exclude="log/slog.*,(*log/slog.Logger).*" ./...
+```
+
+#### With golangci-lint
+
+In your `.golangci.yml`:
+
+```yaml
+linters:
+  enable:
+    - noctx
+
+linters-settings:
+  noctx:
+    # Exclude specific functions using glob patterns (* wildcards)
+    exclude:
+      # Exclude all log/slog package functions
+      - "log/slog.*"
+      # Exclude all methods on log/slog.Logger
+      - "(*log/slog.Logger).*"
+      # Exclude specific functions
+      - "log/slog.Debug"
+      - "log/slog.Info"
+```
+
+The exclusion patterns support standard glob patterns with `*` wildcards.
+
 ## net/http package
 ### Rules
 https://github.com/sonatard/noctx/blob/03bbcad02284bb6257428c0e5d489e0d113bfee8/noctx.go#L41-L50

--- a/noctx_test.go
+++ b/noctx_test.go
@@ -26,3 +26,40 @@ func TestAnalyzer(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalyzerWithExclusions(t *testing.T) {
+	// Test with slog functions excluded
+	t.Run("exclude_slog", func(t *testing.T) {
+		// Save current flag value and restore after test
+		oldExclude := noctx.Analyzer.Flags.Lookup("exclude")
+		if oldExclude != nil {
+			defer func() {
+				_ = noctx.Analyzer.Flags.Set("exclude", oldExclude.Value.String())
+			}()
+		}
+
+		// Set exclusion patterns
+		if err := noctx.Analyzer.Flags.Set("exclude", "log/slog.*,(*log/slog.Logger).*"); err != nil {
+			t.Fatalf("Failed to set exclude flag: %v", err)
+		}
+		analysistest.Run(t, analysistest.TestData(), noctx.Analyzer, "slog_excluded")
+	})
+
+	// Test with partial exclusion
+	t.Run("exclude_partial", func(t *testing.T) {
+		// Save current flag value and restore after test
+		oldExclude := noctx.Analyzer.Flags.Lookup("exclude")
+		if oldExclude != nil {
+			defer func() {
+				_ = noctx.Analyzer.Flags.Set("exclude", oldExclude.Value.String())
+			}()
+		}
+
+		// Only exclude Debug methods
+		if err := noctx.Analyzer.Flags.Set("exclude", "log/slog.Debug,(*log/slog.Logger).Debug"); err != nil {
+			t.Fatalf("Failed to set exclude flag: %v", err)
+		}
+
+		analysistest.Run(t, analysistest.TestData(), noctx.Analyzer, "slog_partial")
+	})
+}

--- a/testdata/src/slog_excluded/slog.go
+++ b/testdata/src/slog_excluded/slog.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+func _() {
+	ctx := context.Background()
+
+	// All slog functions are excluded - no warnings expected
+	slog.Debug("debug message", slog.String("key", "value"))
+	slog.Warn("warn message", slog.String("key", "value"))
+	slog.Error("error message", slog.String("key", "value"))
+	slog.Info("info message", slog.String("key", "value"))
+
+	// Context versions are always fine
+	slog.DebugContext(ctx, "debug message", slog.String("key", "value"))
+	slog.WarnContext(ctx, "warn message", slog.String("key", "value"))
+	slog.ErrorContext(ctx, "error message", slog.String("key", "value"))
+	slog.InfoContext(ctx, "info message", slog.String("key", "value"))
+
+	// Logger methods are also excluded - no warnings expected
+	l := slog.New(slog.NewTextHandler(nil, nil))
+	l.Debug("debug message", slog.String("key", "value"))
+	l.Warn("warn message", slog.String("key", "value"))
+	l.Error("error message", slog.String("key", "value"))
+	l.Info("info message", slog.String("key", "value"))
+
+	// But other packages should still be checked
+	http.Get("https://example.com") // want `net/http.Get must not be called`
+}

--- a/testdata/src/slog_partial/slog.go
+++ b/testdata/src/slog_partial/slog.go
@@ -1,0 +1,29 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+)
+
+func _() {
+	ctx := context.Background()
+
+	// Only Debug methods are excluded
+	slog.Debug("debug message", slog.String("key", "value")) // no warning - excluded
+	slog.Warn("warn message", slog.String("key", "value"))   // want `log/slog.Warn must not be called`
+	slog.Error("error message", slog.String("key", "value")) // want `log/slog.Error must not be called`
+	slog.Info("info message", slog.String("key", "value"))   // want `log/slog.Info must not be called`
+
+	// Context versions are always fine
+	slog.DebugContext(ctx, "debug message", slog.String("key", "value"))
+	slog.WarnContext(ctx, "warn message", slog.String("key", "value"))
+	slog.ErrorContext(ctx, "error message", slog.String("key", "value"))
+	slog.InfoContext(ctx, "info message", slog.String("key", "value"))
+
+	// Logger methods - only Debug is excluded
+	l := slog.New(slog.NewTextHandler(nil, nil))
+	l.Debug("debug message", slog.String("key", "value")) // no warning - excluded
+	l.Warn("warn message", slog.String("key", "value"))   // want `\(\*log/slog.Logger\).Warn must not be called`
+	l.Error("error message", slog.String("key", "value")) // want `\(\*log/slog.Logger\).Error must not be called`
+	l.Info("info message", slog.String("key", "value"))   // want `\(\*log/slog.Logger\).Info must not be called`
+}


### PR DESCRIPTION
## Summary

This PR adds pattern-based exclusion functionality to the noctx analyzer, allowing users to exclude specific functions from context checks. This is particularly useful for packages like `log/slog` where context variants are optional.

## Motivation

As discussed, the `log/slog` package intentionally provides both context and non-context variants of logging functions. Unlike other packages that predate the context package, slog was designed with context support from the start. Organizations may have different policies about whether to enforce context usage for logging.

## Changes

- Added `exclude` flag to the analyzer that accepts comma-separated glob patterns
- Implemented pattern matching using Go's `filepath.Match` for flexibility
- Refactored the analyzer code to improve maintainability and reduce cyclomatic complexity
- Added comprehensive tests for exclusion scenarios
- Updated documentation with configuration examples

## Usage Examples

### With go vet
```bash
go vet -vettool=$(which noctx) -noctx.exclude="log/slog.*,(*log/slog.Logger).*" ./...
```

### With golangci-lint
```yaml
linters-settings:
  noctx:
    exclude:
      - "log/slog.*"
      - "(*log/slog.Logger).*"
```

## Testing

The PR includes tests for:
- Complete exclusion of all slog functions
- Partial exclusion (e.g., only Debug methods)
- Verification that non-excluded functions are still checked

All existing tests continue to pass, ensuring backward compatibility.